### PR TITLE
back ProfessionalClient GetClients

### DIFF
--- a/Backend/API/Controllers/ProfessionalClientController.cs
+++ b/Backend/API/Controllers/ProfessionalClientController.cs
@@ -1,4 +1,6 @@
-﻿using Core.Services.Interfaces;
+﻿using Azure;
+using Core.Services.Interfaces;
+using DTOs;
 using DTOs.Client;
 using DTOs.Identity;
 using Microsoft.AspNetCore.Authorization;
@@ -38,5 +40,29 @@ public class ProfessionalClientController : ControllerBase
             return Ok(result);
         else
             return NotFound(new { message = $"Client with ID {clientId} not found." });
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<ServiceResponse<List<ClientListDto>>>> GetAllClients()
+    {
+        var result = await _clientService.GetClients();
+        if (result == null)
+        {
+            return StatusCode(500, new { message = "Internal server error occurred." });
+        }
+
+        if (result.Success)
+        {
+            if (result.Data == null || result.Data.Count == 0)
+            {
+                return NotFound(new { message = "No clients found." });
+            }
+
+            return Ok(result);
+        }
+        else
+        {
+            return BadRequest(new { message = result.Message });
+        }
     }
 }

--- a/Backend/Core/Services/ClientService.cs
+++ b/Backend/Core/Services/ClientService.cs
@@ -5,6 +5,7 @@ using DTOs;
 using DTOs.Client;
 using DTOs.Identity;
 using Infrastructure.Repositories.Interfaces;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
 namespace Core.Services;
@@ -84,6 +85,29 @@ public class ClientService : IClientService
             serviceResponse.Success = false;
             serviceResponse.Message = ex.Message;
             _logger.LogError(ex, $"{ex.Message}");
+        }
+
+        return serviceResponse;
+    }
+
+    public async Task<ServiceResponse<List<ClientListDto>>> GetClients()
+    {
+        var serviceResponse = new ServiceResponse<List<ClientListDto>>();
+        try
+        {
+            var clients = await _clientRepository.GetAll()
+               .Include(c => c.ApplicationUser)
+               .ToListAsync();
+
+            var clientsList = _mapper.Map<List<ClientListDto>>(clients);
+
+            serviceResponse.Data = clientsList;
+        }
+        catch (Exception ex)
+        {
+            serviceResponse.Success = false;
+            serviceResponse.Message = ex.Message;
+            _logger.LogError(ex, $"Error getting Clients - {ex.Message}");
         }
 
         return serviceResponse;

--- a/Backend/Core/Services/Interfaces/IClientService.cs
+++ b/Backend/Core/Services/Interfaces/IClientService.cs
@@ -9,4 +9,5 @@ public interface IClientService
     //Task<ClientCreatedDto> AddClientAsync(Guid professionalId, ClientAddDto clientAddDto);
     Task<ServiceResponse<RegistrationResponse>> RegisterClientUser(Guid professionalId, ClientAddDto clientDto);
     Task<ServiceResponse<ClientGetDto>> GetClientById(Guid id);
+    Task<ServiceResponse<List<ClientListDto>>> GetClients();
 }

--- a/Backend/DTOs/Client/ClientListDto.cs
+++ b/Backend/DTOs/Client/ClientListDto.cs
@@ -1,0 +1,10 @@
+﻿
+namespace DTOs.Client;
+
+public class ClientListDto
+{
+    public Guid Id { get; set; }
+    public string FirstName { get; set; }
+    public string LastName { get; set; }
+    public string PhoneNumber { get; set; }
+}

--- a/Backend/Infrastructure/Repositories/Interfaces/IClientRepository.cs
+++ b/Backend/Infrastructure/Repositories/Interfaces/IClientRepository.cs
@@ -7,5 +7,4 @@ public interface IClientRepository : IGenericRepository<Client, Guid>
 {
     //public Task<ClientCreatedDto> Insert(ClientAddDto clientAddDto);
     Task<ClientGetDto?> GetById(Guid id);
-
 }

--- a/Backend/Mappings/Profiles/ClientProfile.cs
+++ b/Backend/Mappings/Profiles/ClientProfile.cs
@@ -15,5 +15,10 @@ public class ClientProfile : Profile
            .ForMember(dest => dest.FirstName, opt => opt.MapFrom(src => src.ApplicationUser.FirstName))
            .ForMember(dest => dest.LastName, opt => opt.MapFrom(src => src.ApplicationUser.LastName));
 
+        CreateMap<Client, ClientListDto>()
+          .ForMember(dest => dest.FirstName, opt => opt.MapFrom(src => src.ApplicationUser.FirstName))
+          .ForMember(dest => dest.LastName, opt => opt.MapFrom(src => src.ApplicationUser.LastName))
+          .ForMember(dest => dest.PhoneNumber, opt => opt.MapFrom(src => src.ApplicationUser.PhoneNumber));
+
     }
 }


### PR DESCRIPTION
## Add GetClients endpoint
This PR introduces a new GetClients endpoint in the ProfessionalClientController and includes the following changes:

- Adds ClientListDto for transferring client data.
- Configures AutoMapper to map Client to ClientListDto.
- Added GetClients method that returns ServiceResponse<ClientListDto>.
- Added the GetClients method to handle HTTP GET requests to fetch client list. 
 
## Test endpoint:
![image](https://github.com/NoCountrySimulacion/EasyTurnos/assets/88550405/1c5df307-4a5b-407a-83dc-23d4360f2b1c)
