### PR TITLE
Remove unnecessary property and relationship

### DIFF
--- a/Backend/API/Controllers/ProfessionalClientController.cs
+++ b/Backend/API/Controllers/ProfessionalClientController.cs
@@ -1,5 +1,4 @@
-﻿using Azure;
-using Core.Services.Interfaces;
+﻿using Core.Services.Interfaces;
 using DTOs;
 using DTOs.Client;
 using DTOs.Identity;
@@ -19,12 +18,6 @@ public class ProfessionalClientController : ControllerBase
     {
         _clientService = clientService;
     }
-
-    //[HttpPost]
-    //public async Task<ActionResult<ClientCreatedDto>> AddClient(Guid professionalId, ClientAddDto clientAddDto)
-    //{
-    //    return Ok(await _clientService.AddClientAsync(professionalId, clientAddDto));
-    //}
 
     [HttpPost("RegisterClient")]
     public async Task<ActionResult<RegistrationResponse>> RegisterClientUser(Guid professionalId, ClientAddDto clientAddDto)

--- a/Backend/Domain/Entities/Client.cs
+++ b/Backend/Domain/Entities/Client.cs
@@ -3,7 +3,6 @@
     public class Client : BaseEntity<Guid>
     {
         public DateTime BirthDate { get; set; }
-        public Guid ApplicationUserId { get; set; }
         public ApplicationUser ApplicationUser { get; set; }
         public ICollection<ProfessionalClient> ProfessionalClients { get; set; }
         public ICollection<Appointment> Appointments { get; set; }

--- a/Backend/Infrastructure/Data/ApplicationDbContext.cs
+++ b/Backend/Infrastructure/Data/ApplicationDbContext.cs
@@ -24,11 +24,6 @@ namespace Infrastructure.Data
             base.OnModelCreating(modelBuilder);
             
             // Client
-            modelBuilder.Entity<Client>()
-                .HasOne(c => c.ApplicationUser)
-                .WithOne(au => au.Client)
-                .HasForeignKey<Client>(c => c.ApplicationUserId);
-
             modelBuilder.Entity<ApplicationUser>()
                 .HasOne(au => au.Client)
                 .WithOne(c => c.ApplicationUser)


### PR DESCRIPTION
This pull request refactors the `ApplicationDbContext` by removing an unnecessary property and its associated relationship. Specifically, the following changes were made:

- Removed the unused `ApplicationUserId` property from the `Client` entity.
- Eliminated the associated relationship in the `ApplicationDbContext`.

## Testing

- Verified that the application builds successfully.
- /api/professionals/{professionalId}/clients/{clientId}: 
![image](https://github.com/NoCountrySimulacion/EasyTurnos/assets/88550405/52a13c71-a84b-45c3-ab24-7149f39f9bfd)
- Entity Client:
![image](https://github.com/NoCountrySimulacion/EasyTurnos/assets/88550405/2703c263-d19a-4eee-8082-8c304e37676f)
