### PR TITLE
back Delete Client

### DIFF
--- a/Backend/API/Controllers/ProfessionalClientController.cs
+++ b/Backend/API/Controllers/ProfessionalClientController.cs
@@ -58,4 +58,23 @@ public class ProfessionalClientController : ControllerBase
             return BadRequest(new { message = result.Message });
         }
     }
+
+    [HttpDelete("{clientId}")]
+    public async Task<IActionResult> RemoveProfessionalClientRelation(Guid professionalId, Guid clientId)
+    {
+        var result = await _clientService.RemoveProfessionalClientRelation(professionalId, clientId);
+
+        if (result.Success)
+        {
+            return Ok(result);
+        }
+        else if (result.Message == "Relation not found.")
+        {
+            return NotFound(result);
+        }
+        else
+        {
+            return BadRequest(new { message = result.Message });
+        }
+    }
 }

--- a/Backend/Core/Services/ClientService.cs
+++ b/Backend/Core/Services/ClientService.cs
@@ -11,7 +11,6 @@ using Microsoft.EntityFrameworkCore;
 namespace Core.Services;
 
 public class ClientService : IClientService
-
 {
     private readonly IClientRepository _clientRepository;
     private readonly IAuthenticationService _authenticationService;
@@ -113,5 +112,25 @@ public class ClientService : IClientService
         }
 
         return serviceResponse;
+    }
+
+    public async Task<ServiceResponse<bool>> RemoveProfessionalClientRelation(Guid professionalId, Guid clientId)
+    {
+        try
+        {
+            var result = await _clientRepository.RemoveProfessionalClientRelation(professionalId, clientId);
+            if (result)
+            {
+                return new ServiceResponse<bool> { Data = true, Success = true, Message = "Relation removed successfully." };
+            }
+            else
+            {
+                return new ServiceResponse<bool> { Data = false, Success = false, Message = "Relation not found." };
+            }
+        }
+        catch (Exception ex)
+        {
+            return new ServiceResponse<bool> { Data = false, Success = false, Message = $"An error occurred: {ex.Message}" };
+        }
     }
 }

--- a/Backend/Core/Services/Interfaces/IClientService.cs
+++ b/Backend/Core/Services/Interfaces/IClientService.cs
@@ -10,4 +10,6 @@ public interface IClientService
     Task<ServiceResponse<RegistrationResponse>> RegisterClientUser(Guid professionalId, ClientAddDto clientDto);
     Task<ServiceResponse<ClientGetDto>> GetClientById(Guid id);
     Task<ServiceResponse<List<ClientListDto>>> GetClients();
+    Task<ServiceResponse<bool>> RemoveProfessionalClientRelation(Guid professionalId, Guid clientId);
+
 }

--- a/Backend/Infrastructure/Repositories/ClientRepository.cs
+++ b/Backend/Infrastructure/Repositories/ClientRepository.cs
@@ -28,5 +28,18 @@ public class ClientRepository : GenericRepository<Client, Guid>, IClientReposito
             .FirstOrDefaultAsync(x => x.Id == id);
     }
 
+    public async Task<bool> RemoveProfessionalClientRelation(Guid professionalId, Guid clientId)
+    {
+        var professionalClient = await _context.ProfessionalClients
+           .FirstOrDefaultAsync(pc => pc.ProfessionalId == professionalId && pc.ClientId == clientId);
 
+        if (professionalClient != null)
+        {
+            _context.ProfessionalClients.Remove(professionalClient);
+            await _context.SaveChangesAsync();
+            return true;
+        }
+
+        return false;
+    }
 }

--- a/Backend/Infrastructure/Repositories/Interfaces/IClientRepository.cs
+++ b/Backend/Infrastructure/Repositories/Interfaces/IClientRepository.cs
@@ -7,4 +7,6 @@ public interface IClientRepository : IGenericRepository<Client, Guid>
 {
     //public Task<ClientCreatedDto> Insert(ClientAddDto clientAddDto);
     Task<ClientGetDto?> GetById(Guid id);
+    Task<bool> RemoveProfessionalClientRelation(Guid professionalId, Guid clientId);
+
 }


### PR DESCRIPTION
## Add endpoint to remove professional-client relation
This PR introduces a new endpoint in the ProfessionalClientController to remove the relation between a professional and a client.

## Test
1. Start the application and ensure it is running correctly.
2. Use an API client (Postman, Insomnia) to send a DELETE request to /api/ProfessionalClient/professionals/{professionalId}/clients/{clientId} with valid IDs.

![image](https://github.com/NoCountrySimulacion/EasyTurnos/assets/88550405/cf5d0098-bb30-4f23-aeed-6ef39fede10d)

![image](https://github.com/NoCountrySimulacion/EasyTurnos/assets/88550405/9f4cfced-bfe8-400a-88af-c4bae5449fab)

