### PR TITLE
Back fix GetClientById

### DIFF
--- a/Backend/API/Controllers/ProfessionalClientController.cs
+++ b/Backend/API/Controllers/ProfessionalClientController.cs
@@ -1,4 +1,5 @@
 ﻿using Core.Services.Interfaces;
+using Domain.Entities;
 using DTOs;
 using DTOs.Client;
 using DTOs.Identity;
@@ -36,9 +37,9 @@ public class ProfessionalClientController : ControllerBase
     }
 
     [HttpGet]
-    public async Task<ActionResult<ServiceResponse<List<ClientListDto>>>> GetAllClients()
+    public async Task<ActionResult<ServiceResponse<List<ClientListDto>>>> GetAllClients(Guid professionalId)
     {
-        var result = await _clientService.GetClients();
+        var result = await _clientService.GetClients(professionalId);
         if (result == null)
         {
             return StatusCode(500, new { message = "Internal server error occurred." });

--- a/Backend/Core/Services/ClientService.cs
+++ b/Backend/Core/Services/ClientService.cs
@@ -92,18 +92,20 @@ public class ClientService : IClientService
         return serviceResponse;
     }
 
-    public async Task<ServiceResponse<List<ClientListDto>>> GetClients()
+    public async Task<ServiceResponse<List<ClientListDto>>> GetClients(Guid professionalId)
     {
         var serviceResponse = new ServiceResponse<List<ClientListDto>>();
         try
         {
             var clients = await _clientRepository.GetAll()
                .Include(c => c.ApplicationUser)
+               .Where(c => c.ProfessionalClients.Any(pc => pc.ProfessionalId == professionalId))
                .ToListAsync();
 
             var clientsList = _mapper.Map<List<ClientListDto>>(clients);
 
             serviceResponse.Data = clientsList;
+            serviceResponse.Message = "Clients retrieved successfully.";
         }
         catch (Exception ex)
         {

--- a/Backend/Core/Services/Interfaces/IClientService.cs
+++ b/Backend/Core/Services/Interfaces/IClientService.cs
@@ -9,5 +9,5 @@ public interface IClientService
     //Task<ClientCreatedDto> AddClientAsync(Guid professionalId, ClientAddDto clientAddDto);
     Task<ServiceResponse<RegistrationResponse>> RegisterClientUser(Guid professionalId, ClientAddDto clientDto);
     Task<ServiceResponse<ClientGetDto>> GetClientById(Guid id);
-    Task<ServiceResponse<List<ClientListDto>>> GetClients();
+    Task<ServiceResponse<List<ClientListDto>>> GetClients(Guid professionalId);
 }


### PR DESCRIPTION
## Fix GetClientById
This PR introduces a new endpoint in the ProfessionalClientsController to get list clients associated with a professional by their ID.

## Test endpoint:
api/professionals/{professionalId}/clients
![image](https://github.com/NoCountrySimulacion/EasyTurnos/assets/88550405/112c80a5-6064-4fce-ab02-92b3f7eb6482)
The clients table has 4 registered clients:
![image](https://github.com/NoCountrySimulacion/EasyTurnos/assets/88550405/6b6720c3-71ed-49da-b487-1e0bb7d06570)


