### PR TITLE
82 back delete all slots by professional

### DIFF
--- a/Backend/API/Controllers/SlotController.cs
+++ b/Backend/API/Controllers/SlotController.cs
@@ -45,5 +45,13 @@ namespace API.Controllers
 
             return Ok(await _slotService.DeleteSlots(professionalId, slotIds));
         }
+
+        [HttpDelete("DeleteAllByProfessionalId")]
+        public async Task<ActionResult<ServiceResponse<bool>>> DeleteAllSlotsByProfessionalId()
+        {
+            var professionalId = GetCurrentProfessionalId();
+
+            return Ok(await _slotService.DeleteAllSlotsByProfessionalId(professionalId));
+        }
     }
 }

--- a/Backend/Core/Services/Interfaces/ISlotService.cs
+++ b/Backend/Core/Services/Interfaces/ISlotService.cs
@@ -8,5 +8,6 @@ namespace Core.Services.Interfaces
         Task<ServiceResponse<bool>> AddSlots(List<SlotAddDto> addSlots, Guid professionalId);
         Task<ServiceResponse<List<SlotGetDto>>> GetAllSlots(Guid professionalId);
         Task<ServiceResponse<bool>> DeleteSlots(Guid professionalId, List<Guid> slotIds);
+        Task<ServiceResponse<bool>> DeleteAllSlotsByProfessionalId(Guid professionalId);
     }
 }

--- a/Backend/Core/Services/SlotService.cs
+++ b/Backend/Core/Services/SlotService.cs
@@ -70,6 +70,28 @@ namespace Core.Services
             return serviceResponse;
         }
 
+        public async Task<ServiceResponse<bool>> DeleteAllSlotsByProfessionalId(Guid professionalId)
+        {
+            var serviceResponse = new ServiceResponse<bool>();
+
+            try
+            {
+                if (await _slotRepository.DeleteAllSlotsByProfessionalId(professionalId))
+                    await _slotRepository.SaveChangesAsync();
+
+                serviceResponse.Data = true;
+                serviceResponse.Message = "Range deleted successfully.";
+            }
+            catch (Exception ex)
+            {
+                serviceResponse.Success = false;
+                serviceResponse.Message = ex.Message;
+                _logger.LogError(ex, ex.Message);
+            }
+
+            return serviceResponse;
+        }
+
         public async Task<ServiceResponse<List<SlotGetDto>>> GetAllSlots(Guid professionalId)
         {
             var serviceResponse = new ServiceResponse<List<SlotGetDto>>();

--- a/Backend/DTOs/Slot/SlotGetDto.cs
+++ b/Backend/DTOs/Slot/SlotGetDto.cs
@@ -2,6 +2,7 @@
 {
     public class SlotGetDto
     {
+        public string Id { get; set; }
         public string Day {  get; set; }
         public DateTime StartDate { get; set; }
         public DateTime EndDate { get; set; }

--- a/Backend/Infrastructure/Repositories/Interfaces/ISlotRepository.cs
+++ b/Backend/Infrastructure/Repositories/Interfaces/ISlotRepository.cs
@@ -7,5 +7,6 @@ namespace Infrastructure.Repositories.Interfaces
     {
         public new Task<List<SlotGetDto>> GetAllSlots(Guid professionalId);
         public new Task<bool> DeleteSlots(Guid professionalId, List<Guid> slotIds);
+        Task<bool> DeleteAllSlotsByProfessionalId(Guid professionalId);
     }
 }

--- a/Backend/Infrastructure/Repositories/SlotRepository.cs
+++ b/Backend/Infrastructure/Repositories/SlotRepository.cs
@@ -40,5 +40,19 @@ namespace Infrastructure.Repositories
 
             return dbEntities.Count > 0;
         }
+
+        public async Task<bool> DeleteAllSlotsByProfessionalId(Guid professionalId)
+        {
+            var dbEntities = await Entities
+                .Where(e => e.ProfessionalId == professionalId)
+                .ToListAsync();
+
+            if (dbEntities.Count > 0)
+            {
+                Entities.RemoveRange(dbEntities);
+            }
+
+            return dbEntities.Count > 0;
+        }
     }
 }


### PR DESCRIPTION
-Add Endpoint DeleteAllByProfessionalId: this mehod delete all the slots added by one professional, in order to avoid being removing them one by one.  

-Update SlotGetDto: now this dto returns Id of the slot. It is necessary to know the id in order to delete specifi slots

To test both changes its necessary to be logged in order to take the ProfessionaId from the JWT